### PR TITLE
👌 IMPROVE: add `far` role

### DIFF
--- a/docs/badges_buttons.md
+++ b/docs/badges_buttons.md
@@ -208,7 +208,8 @@ If the theme you are using does not already include the FontAwesome CSS, it shou
 html_css_files = ["https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/fontawesome.min.css"]
 ```
 
-Use either `fa` (deprecated in font-awesome v5), `fas` or `fab` for the role name.
+Use either `fa` (deprecated in font-awesome v5), `fas`, `fab` or `far` for the role name.
+Note that not all regular style icons are free, `far` role only works with free ones.
 
 ````{tab-set-code}
 ```markdown

--- a/sphinx_design/icons.py
+++ b/sphinx_design/icons.py
@@ -29,7 +29,7 @@ OCTICON_CSS = """\
 def setup_icons(app: Sphinx) -> None:
     app.add_role("octicon", OcticonRole())
     app.add_directive("_all-octicon", AllOcticons)
-    for style in ["fa", "fas", "fab"]:
+    for style in ["fa", "fas", "fab", "far"]:
         # note: fa is deprecated in v5, fas is the default and fab is the other free option
         app.add_role(style, FontawesomeRole(style))
     app.add_config_value("sd_fontawesome_latex", False, "env")


### PR DESCRIPTION
Adds `far` role to support free regular style icons. Not all regular style icons
are free but more than a hundred are so I believe this to be a worthy addition.

Closes #31.

I have tested locally it works for those regular style icons that are free, I am not
sure if I also have to add tests as part of the PR.
