### PR TITLE
🐛 FIX: Links in card titles

### DIFF
--- a/docs/cards.md
+++ b/docs/cards.md
@@ -1,4 +1,4 @@
-(cards)=
+(sd-cards)=
 
 # Cards
 

--- a/docs/dropdowns.md
+++ b/docs/dropdowns.md
@@ -1,4 +1,4 @@
-(dropdowns)=
+(sd-dropdowns)=
 
 # Dropdowns
 

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -1,4 +1,4 @@
-(grids)=
+(sd-grids)=
 
 # Grids
 

--- a/docs/snippets/myst/card-title-link.txt
+++ b/docs/snippets/myst/card-title-link.txt
@@ -1,0 +1,5 @@
+(target)=
+:::{card} Card Title <https://example.com> {ref}`link <target>`
+
+Card content
+:::

--- a/docs/snippets/rst/card-title-link.txt
+++ b/docs/snippets/rst/card-title-link.txt
@@ -1,0 +1,4 @@
+.. _target:
+.. card:: Card Title https://example.com :ref:`link <target>`
+
+    Card content

--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -1,4 +1,4 @@
-(tabs)=
+(sd-tabs)=
 
 # Tabs
 

--- a/sphinx_design/cards.py
+++ b/sphinx_design/cards.py
@@ -134,7 +134,9 @@ class CardDirective(SphinxDirective):
                 + options.get("class-title", []),
             )
             textnodes, _ = inst.state.inline_text(arguments[0], inst.lineno)
-            title.extend(textnodes)
+            title_container = PassthroughTextElement()
+            title_container.extend(textnodes)
+            title.append(title_container)
             body.insert(0, title)
         container.append(body)
 

--- a/sphinx_design/shared.py
+++ b/sphinx_design/shared.py
@@ -103,4 +103,6 @@ class PassthroughTextElement(nodes.TextElement):
     """A text element which will not render anything.
 
     This is required for reference node to render correctly outside of paragraphs.
+    Since sphinx expects them to be within a ``TextElement``:
+    https://github.com/sphinx-doc/sphinx/blob/068f802df90ea790f89319094e407c4d5f6c26ff/sphinx/writers/html5.py#L224
     """

--- a/tests/test_snippets/snippet_post_card-basic.xml
+++ b/tests/test_snippets/snippet_post_card-basic.xml
@@ -5,6 +5,7 @@
         <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
             <container classes="sd-card-body" design_component="card-body" is_div="True">
                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                    Card Title
+                    <PassthroughTextElement>
+                        Card Title
                 <paragraph classes="sd-card-text">
                     Card content

--- a/tests/test_snippets/snippet_post_card-carousel.xml
+++ b/tests/test_snippets/snippet_post_card-carousel.xml
@@ -6,13 +6,15 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 1
+                        <PassthroughTextElement>
+                            card 1
                     <paragraph classes="sd-card-text">
                         content
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 2
+                        <PassthroughTextElement>
+                            card 2
                     <paragraph classes="sd-card-text">
                         Longer
                     <paragraph classes="sd-card-text">
@@ -20,16 +22,20 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 3
+                        <PassthroughTextElement>
+                            card 3
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 4
+                        <PassthroughTextElement>
+                            card 4
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 5
+                        <PassthroughTextElement>
+                            card 5
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 6
+                        <PassthroughTextElement>
+                            card 6

--- a/tests/test_snippets/snippet_post_card-head-foot.xml
+++ b/tests/test_snippets/snippet_post_card-head-foot.xml
@@ -8,7 +8,8 @@
                     Header
             <container classes="sd-card-body" design_component="card-body" is_div="True">
                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                    Card Title
+                    <PassthroughTextElement>
+                        Card Title
                 <paragraph classes="sd-card-text">
                     Card content
             <container classes="sd-card-footer" design_component="card-footer" is_div="True">

--- a/tests/test_snippets/snippet_post_card-images.xml
+++ b/tests/test_snippets/snippet_post_card-images.xml
@@ -10,7 +10,8 @@
                         <container classes="sd-card-img-overlay" design_component="card-overlay" is_div="True">
                             <container classes="sd-card-body" design_component="card-body" is_div="True">
                                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                    Title
+                                    <PassthroughTextElement>
+                                        Title
                                 <paragraph classes="sd-card-text">
                                     Text
                 <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
@@ -21,7 +22,8 @@
                                 Header
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title
+                                <PassthroughTextElement>
+                                    Title
                             <paragraph classes="sd-card-text">
                                 Content
                         <container classes="sd-card-footer" design_component="card-footer" is_div="True">
@@ -34,7 +36,8 @@
                                 Header
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title
+                                <PassthroughTextElement>
+                                    Title
                             <paragraph classes="sd-card-text">
                                 Content
                         <container classes="sd-card-footer" design_component="card-footer" is_div="True">

--- a/tests/test_snippets/snippet_post_card-link.xml
+++ b/tests/test_snippets/snippet_post_card-link.xml
@@ -9,7 +9,8 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        Clickable Card (external)
+                        <PassthroughTextElement>
+                            Clickable Card (external)
                     <paragraph classes="sd-card-text">
                         The entire card can be clicked to navigate to 
                         <reference refuri="https://example.com">
@@ -20,7 +21,8 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        Clickable Card (internal)
+                        <PassthroughTextElement>
+                            Clickable Card (internal)
                     <paragraph classes="sd-card-text">
                         The entire card can be clicked to navigate to the 
                         <literal>

--- a/tests/test_snippets/snippet_post_card-title-link.xml
+++ b/tests/test_snippets/snippet_post_card-title-link.xml
@@ -1,0 +1,18 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <target refid="target">
+        <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" ids="target" is_div="True" names="target">
+            <container classes="sd-card-body" design_component="card-body" is_div="True">
+                <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
+                    <PassthroughTextElement>
+                        Card Title 
+                        <reference refuri="https://example.com">
+                            https://example.com
+                         
+                        <reference internal="True" refid="target">
+                            <inline classes="std std-ref">
+                                link
+                <paragraph classes="sd-card-text">
+                    Card content

--- a/tests/test_snippets/snippet_post_grid-card.xml
+++ b/tests/test_snippets/snippet_post_grid-card.xml
@@ -8,13 +8,15 @@
                     <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title 1
+                                <PassthroughTextElement>
+                                    Title 1
                             <paragraph classes="sd-card-text">
                                 A
                 <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                     <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title 2
+                                <PassthroughTextElement>
+                                    Title 2
                             <paragraph classes="sd-card-text">
                                 B

--- a/tests/test_snippets/snippet_post_grid-nested.xml
+++ b/tests/test_snippets/snippet_post_grid-nested.xml
@@ -11,7 +11,8 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 1.1
+                                            <PassthroughTextElement>
+                                                Item 1.1
                                         <paragraph classes="sd-card-text">
                                             Multi-line
                                         <paragraph classes="sd-card-text">
@@ -20,7 +21,8 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 1.2
+                                            <PassthroughTextElement>
+                                                Item 1.2
                                         <paragraph classes="sd-card-text">
                                             Content
                 <container classes="sd-col sd-d-flex-column" design_component="grid-item" is_div="True">
@@ -30,20 +32,23 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.1
+                                            <PassthroughTextElement>
+                                                Item 2.1
                                         <paragraph classes="sd-card-text">
                                             Content
                             <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.2
+                                            <PassthroughTextElement>
+                                                Item 2.2
                                         <paragraph classes="sd-card-text">
                                             Content
                             <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.3
+                                            <PassthroughTextElement>
+                                                Item 2.3
                                         <paragraph classes="sd-card-text">
                                             Content

--- a/tests/test_snippets/snippet_pre_card-basic.xml
+++ b/tests/test_snippets/snippet_pre_card-basic.xml
@@ -5,6 +5,7 @@
         <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
             <container classes="sd-card-body" design_component="card-body" is_div="True">
                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                    Card Title
+                    <PassthroughTextElement>
+                        Card Title
                 <paragraph classes="sd-card-text">
                     Card content

--- a/tests/test_snippets/snippet_pre_card-carousel.xml
+++ b/tests/test_snippets/snippet_pre_card-carousel.xml
@@ -6,13 +6,15 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 1
+                        <PassthroughTextElement>
+                            card 1
                     <paragraph classes="sd-card-text">
                         content
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 2
+                        <PassthroughTextElement>
+                            card 2
                     <paragraph classes="sd-card-text">
                         Longer
                     <paragraph classes="sd-card-text">
@@ -20,16 +22,20 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 3
+                        <PassthroughTextElement>
+                            card 3
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 4
+                        <PassthroughTextElement>
+                            card 4
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 5
+                        <PassthroughTextElement>
+                            card 5
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        card 6
+                        <PassthroughTextElement>
+                            card 6

--- a/tests/test_snippets/snippet_pre_card-head-foot.xml
+++ b/tests/test_snippets/snippet_pre_card-head-foot.xml
@@ -8,7 +8,8 @@
                     Header
             <container classes="sd-card-body" design_component="card-body" is_div="True">
                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                    Card Title
+                    <PassthroughTextElement>
+                        Card Title
                 <paragraph classes="sd-card-text">
                     Card content
             <container classes="sd-card-footer" design_component="card-footer" is_div="True">

--- a/tests/test_snippets/snippet_pre_card-images.xml
+++ b/tests/test_snippets/snippet_pre_card-images.xml
@@ -10,7 +10,8 @@
                         <container classes="sd-card-img-overlay" design_component="card-overlay" is_div="True">
                             <container classes="sd-card-body" design_component="card-body" is_div="True">
                                 <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                    Title
+                                    <PassthroughTextElement>
+                                        Title
                                 <paragraph classes="sd-card-text">
                                     Text
                 <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
@@ -21,7 +22,8 @@
                                 Header
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title
+                                <PassthroughTextElement>
+                                    Title
                             <paragraph classes="sd-card-text">
                                 Content
                         <container classes="sd-card-footer" design_component="card-footer" is_div="True">
@@ -34,7 +36,8 @@
                                 Header
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title
+                                <PassthroughTextElement>
+                                    Title
                             <paragraph classes="sd-card-text">
                                 Content
                         <container classes="sd-card-footer" design_component="card-footer" is_div="True">

--- a/tests/test_snippets/snippet_pre_card-link.xml
+++ b/tests/test_snippets/snippet_pre_card-link.xml
@@ -9,7 +9,8 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        Clickable Card (external)
+                        <PassthroughTextElement>
+                            Clickable Card (external)
                     <paragraph classes="sd-card-text">
                         The entire card can be clicked to navigate to 
                         <reference refuri="https://example.com">
@@ -20,7 +21,8 @@
             <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
                 <container classes="sd-card-body" design_component="card-body" is_div="True">
                     <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                        Clickable Card (internal)
+                        <PassthroughTextElement>
+                            Clickable Card (internal)
                     <paragraph classes="sd-card-text">
                         The entire card can be clicked to navigate to the 
                         <literal>

--- a/tests/test_snippets/snippet_pre_card-title-link.xml
+++ b/tests/test_snippets/snippet_pre_card-title-link.xml
@@ -1,0 +1,18 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <target refid="target">
+        <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" ids="target" is_div="True" names="target">
+            <container classes="sd-card-body" design_component="card-body" is_div="True">
+                <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
+                    <PassthroughTextElement>
+                        Card Title 
+                        <reference refuri="https://example.com">
+                            https://example.com
+                         
+                        <pending_xref refdoc="index" refdomain="std" refexplicit="True" reftarget="target" reftype="ref" refwarn="True">
+                            <inline classes="xref std std-ref">
+                                link
+                <paragraph classes="sd-card-text">
+                    Card content

--- a/tests/test_snippets/snippet_pre_grid-card.xml
+++ b/tests/test_snippets/snippet_pre_grid-card.xml
@@ -8,13 +8,15 @@
                     <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title 1
+                                <PassthroughTextElement>
+                                    Title 1
                             <paragraph classes="sd-card-text">
                                 A
                 <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                     <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                         <container classes="sd-card-body" design_component="card-body" is_div="True">
                             <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                Title 2
+                                <PassthroughTextElement>
+                                    Title 2
                             <paragraph classes="sd-card-text">
                                 B

--- a/tests/test_snippets/snippet_pre_grid-nested.xml
+++ b/tests/test_snippets/snippet_pre_grid-nested.xml
@@ -11,7 +11,8 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 1.1
+                                            <PassthroughTextElement>
+                                                Item 1.1
                                         <paragraph classes="sd-card-text">
                                             Multi-line
                                         <paragraph classes="sd-card-text">
@@ -20,7 +21,8 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 1.2
+                                            <PassthroughTextElement>
+                                                Item 1.2
                                         <paragraph classes="sd-card-text">
                                             Content
                 <container classes="sd-col sd-d-flex-column" design_component="grid-item" is_div="True">
@@ -30,20 +32,23 @@
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.1
+                                            <PassthroughTextElement>
+                                                Item 2.1
                                         <paragraph classes="sd-card-text">
                                             Content
                             <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.2
+                                            <PassthroughTextElement>
+                                                Item 2.2
                                         <paragraph classes="sd-card-text">
                                             Content
                             <container classes="sd-col sd-d-flex-row" design_component="grid-item" is_div="True">
                                 <container classes="sd-card sd-sphinx-override sd-w-100 sd-shadow-sm" design_component="card" is_div="True">
                                     <container classes="sd-card-body" design_component="card-body" is_div="True">
                                         <container classes="sd-card-title sd-font-weight-bold" design_component="card-title" is_div="True">
-                                            Item 2.3
+                                            <PassthroughTextElement>
+                                                Item 2.3
                                         <paragraph classes="sd-card-text">
                                             Content


### PR DESCRIPTION
fixes #28

Sphinx expects that references are within another `TextElement` (e.g. a paragraph), see: https://github.com/sphinx-doc/sphinx/blob/068f802df90ea790f89319094e407c4d5f6c26ff/sphinx/writers/html5.py#L224

To "simulate" this, we wrap the rendered title nodes within a `PassthroughTextElement`, which is ignored on visits.