### PR TITLE
Update: isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     - id: isort
 


### PR DESCRIPTION
Running `pre-commit run --all-files` on
ref `6df4751`, the current `main` branch,
fails to complete and reports the foll in
the error:

```
[extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

This seems to be the same error as https://github.com/PyCQA/isort/issues/2077.

I'm proposing that we update to the same isort
that the isort repo currently uses.