### PR TITLE
🐛 Fix tab-item label with nested syntax

### DIFF
--- a/docs/snippets/myst/tab-options.txt
+++ b/docs/snippets/myst/tab-options.txt
@@ -1,7 +1,7 @@
 ::::{tab-set}
 :class: class-set
 
-:::{tab-item} Label
+:::{tab-item} **Label**
 :name: target
 :selected:
 :class-container: class-container

--- a/docs/snippets/rst/tab-options.txt
+++ b/docs/snippets/rst/tab-options.txt
@@ -1,7 +1,7 @@
 .. tab-set::
     :class: class-set
 
-    .. tab-item:: Label
+    .. tab-item:: **Label**
         :name: target
         :selected:
         :class-container: class-container

--- a/sphinx_design/tabs.py
+++ b/sphinx_design/tabs.py
@@ -99,6 +99,7 @@ class TabItemDirective(SphinxDirective):
         textnodes, _ = self.state.inline_text(self.arguments[0], self.lineno)
         tab_label = nodes.rubric(
             self.arguments[0],
+            "",
             *textnodes,
             classes=["sd-tab-label", *self.options.get("class-label", [])],
         )
@@ -255,6 +256,7 @@ class TabSetHtmlTransform(SphinxPostTransform):
 
                 # create: <label for="id">...</label>
                 label_node = sd_tab_label(
+                    "",
                     "",
                     *tab_label.children,
                     input_id=tab_item_identity,

--- a/tests/test_snippets/snippet_post_tab-options.xml
+++ b/tests/test_snippets/snippet_post_tab-options.xml
@@ -5,7 +5,8 @@
         <container classes="sd-tab-set class-set" design_component="tab-set" is_div="True">
             <sd_tab_input checked="True" id="sd-tab-item-0" set_id="sd-tab-set-0" type="radio">
             <sd_tab_label classes="sd-tab-label class-label" ids="target" input_id="sd-tab-item-0">
-                Label
+                <strong>
+                    Label
             <container classes="sd-tab-content class-content" design_component="tab-content" is_div="True">
                 <paragraph>
                     Content

--- a/tests/test_snippets/snippet_pre_tab-options.xml
+++ b/tests/test_snippets/snippet_pre_tab-options.xml
@@ -5,7 +5,8 @@
         <container classes="sd-tab-set class-set" design_component="tab-set" is_div="True">
             <container classes="sd-tab-item class-container" design_component="tab-item" is_div="True" selected="True">
                 <rubric classes="sd-tab-label class-label" ids="target" names="target">
-                    Label
+                    <strong>
+                        Label
                 <container classes="sd-tab-content class-content" design_component="tab-content" is_div="True">
                     <paragraph>
                         Content


### PR DESCRIPTION
I'm not used to submitting pull requests so please excuse me if I've made any mistakes. 

For my project, I had created a custom role which changed the color of specific words. Using such words in tab labels was not possible. I noticed in the code that the regions which did not allow this were missing arguments in `nodes.rubric` and `sd_tab_label`, both of which are `nodes.TextElement`.