### PR TITLE
👌 Improve specificity of JS function name

### DIFF
--- a/sphinx_design/compiled/sd_tabs.js
+++ b/sphinx_design/compiled/sd_tabs.js
@@ -5,7 +5,7 @@ function ready() {
   for (const label of li) {
     syncId = label.getAttribute("data-sync-id");
     if (syncId) {
-      label.onclick = onLabelClick;
+      label.onclick = onSDLabelClick;
       if (!sd_labels_by_text[syncId]) {
         sd_labels_by_text[syncId] = [];
       }
@@ -14,7 +14,7 @@ function ready() {
   }
 }
 
-function onLabelClick() {
+function onSDLabelClick() {
   // Activate other inputs with the same sync id.
   syncId = this.getAttribute("data-sync-id");
   for (label of sd_labels_by_text[syncId]) {


### PR DESCRIPTION
This PR comes to fix a namespace issue when a Sphinx project uses both, sphinx-design and sphinx-inline-tabs. Both extensions have quite similar JavaScript functionality, sharing the name of the two functions (`ready` and `onLabelClick`). Given that the JavaScript modules (in both cases) are not protected within a namespace, when using **sphinx-inline-tabs** (I mean, using `.. tab:: <label>` from sphinx-inline-tabs) fails to work because sphinx-design's `onLabelClick` was loaded after and its `onLabelClick` overrides the same function from sphinx-inline-tabs. The code from sphinx-inline-tabs seems older, that's why I kindly submit the PR here. Thanks by the way for this great Sphinx extension.