### PR TITLE
:wrench: MAINTAIN: define build.os for RTD to fix build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-  version: "3.8"
   install:
       - method: pip
         path: .


### PR DESCRIPTION
In October, readthedocs started requiring projects to define build.os as documented here: https://blog.readthedocs.com/use-build-os-config/

Recent PR builds on RTD have failed, as shown here: https://readthedocs.org/projects/sphinx-design/builds/22978116/

This PR defines build.os and tools which is also required.