### PR TITLE
✨ NEW: Create custom directives

### DIFF
--- a/docs/additional.md
+++ b/docs/additional.md
@@ -19,7 +19,7 @@ normally positioned just below the title of the article (shown below with non-st
 :class-container: sd-p-2 sd-outline-muted sd-rounded-1
 ```
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/article-info.txt

--- a/docs/additional.md
+++ b/docs/additional.md
@@ -19,9 +19,7 @@ normally positioned just below the title of the article (shown below with non-st
 :class-container: sd-p-2 sd-outline-muted sd-rounded-1
 ```
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/article-info.txt

--- a/docs/badges_buttons.md
+++ b/docs/badges_buttons.md
@@ -17,7 +17,7 @@ Badges are available in each semantic color, with filled and outline variants:
 - {bdg-light}`light`, {bdg-light-line}`light-line`
 - {bdg-dark}`dark`, {bdg-dark-line}`dark-line`
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/badge-basic.txt
@@ -38,7 +38,7 @@ The syntax is the same as for the `ref` role.
 
 {bdg-ref-primary}`badges`
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/badge-link.txt
@@ -90,7 +90,7 @@ Button text
 Reference Button text
 ```
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/button-link.txt

--- a/docs/badges_buttons.md
+++ b/docs/badges_buttons.md
@@ -17,9 +17,7 @@ Badges are available in each semantic color, with filled and outline variants:
 - {bdg-light}`light`, {bdg-light-line}`light-line`
 - {bdg-dark}`dark`, {bdg-dark-line}`dark-line`
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/badge-basic.txt
@@ -40,9 +38,7 @@ The syntax is the same as for the `ref` role.
 
 {bdg-ref-primary}`badges`
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/badge-link.txt
@@ -94,9 +90,7 @@ Button text
 Reference Button text
 ```
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/button-link.txt

--- a/docs/cards.md
+++ b/docs/cards.md
@@ -13,7 +13,7 @@ Card content
 
 See the [Material Design](https://material.io/components/cards) and [Bootstrap card](https://getbootstrap.com/docs/5.0/layout/grid/) descriptions for further details.
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-basic.txt
@@ -36,7 +36,7 @@ Card content
 Footer
 :::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-head-foot.txt
@@ -111,7 +111,7 @@ Footer
 
 :::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-images.txt
@@ -145,7 +145,7 @@ The entire card can be clicked to navigate to <https://example.com>.
 The entire card can be clicked to navigate to the `cards-clickable` reference target.
 :::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-link.txt
@@ -215,7 +215,7 @@ content
 :::
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-carousel.txt

--- a/docs/cards.md
+++ b/docs/cards.md
@@ -13,9 +13,7 @@ Card content
 
 See the [Material Design](https://material.io/components/cards) and [Bootstrap card](https://getbootstrap.com/docs/5.0/layout/grid/) descriptions for further details.
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-basic.txt
@@ -38,9 +36,7 @@ Card content
 Footer
 :::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-head-foot.txt
@@ -115,9 +111,7 @@ Footer
 
 :::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-images.txt
@@ -151,9 +145,7 @@ The entire card can be clicked to navigate to <https://example.com>.
 The entire card can be clicked to navigate to the `cards-clickable` reference target.
 :::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-link.txt
@@ -223,9 +215,7 @@ content
 :::
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/card-carousel.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,15 @@ extensions = ["myst_parser", "sphinx_design"]
 
 suppress_warnings = ["design.fa-build"]
 sd_fontawesome_latex = True
+sd_custom_directives = {
+    "dropdown-syntax": {
+        "inherit": "dropdown",
+        "options": {
+            "color": "primary",
+            "icon": "code",
+        },
+    }
+}
 
 html_theme = os.environ.get("SPHINX_THEME", "alabaster")
 html_title = f"Sphinx Design ({html_theme.replace('_', '-')})"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ sd_fontawesome_latex = True
 sd_custom_directives = {
     "dropdown-syntax": {
         "inherit": "dropdown",
+        "argument": "Syntax",
         "options": {
             "color": "primary",
             "icon": "code",

--- a/docs/css_classes.md
+++ b/docs/css_classes.md
@@ -9,9 +9,7 @@ All CSS classes that are part of sphinx-design are prefixed with `sd-`.
 Some CSS styled text
 :::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/div-basic.txt

--- a/docs/css_classes.md
+++ b/docs/css_classes.md
@@ -9,7 +9,7 @@ All CSS classes that are part of sphinx-design are prefixed with `sd-`.
 Some CSS styled text
 :::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/div-basic.txt

--- a/docs/dropdowns.md
+++ b/docs/dropdowns.md
@@ -20,9 +20,7 @@ Dropdown content
 Dropdown content
 :::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/dropdown-basic.txt

--- a/docs/dropdowns.md
+++ b/docs/dropdowns.md
@@ -20,7 +20,7 @@ Dropdown content
 Dropdown content
 :::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/dropdown-basic.txt

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -43,6 +43,27 @@ sd_hide_title: true
 :::
 ::::
 
+### Creating custom directives
+
+You can use the `sd_custom_directives` configuration option in your `conf.py` to add custom directives, with default option values:
+
+```python
+sd_custom_directives = {
+    "dropdown-syntax": {
+        "inherit": "dropdown",
+        "options": {
+            "color": "primary",
+            "icon": "code",
+        },
+    }
+}
+```
+
+The key is the new directive name to add, and the value is a dictionary with the following keys:
+
+- `inherit`: The directive to inherit from (e.g. `dropdown`)
+- `options`: A dictionary of default options for the directive
+
 ## Supported browsers
 
 - Chrome >= 60

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -51,6 +51,7 @@ You can use the `sd_custom_directives` configuration option in your `conf.py` to
 sd_custom_directives = {
     "dropdown-syntax": {
         "inherit": "dropdown",
+        "argument": "Syntax",
         "options": {
             "color": "primary",
             "icon": "code",
@@ -62,7 +63,8 @@ sd_custom_directives = {
 The key is the new directive name to add, and the value is a dictionary with the following keys:
 
 - `inherit`: The directive to inherit from (e.g. `dropdown`)
-- `options`: A dictionary of default options for the directive
+- `argument`: The default argument (optional, only for directives that take a single optional argument)
+- `options`: A dictionary of default options for the directive (optional)
 
 ## Supported browsers
 

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -63,7 +63,7 @@ sd_custom_directives = {
 The key is the new directive name to add, and the value is a dictionary with the following keys:
 
 - `inherit`: The directive to inherit from (e.g. `dropdown`)
-- `argument`: The default argument (optional, only for directives that take a single optional argument)
+- `argument`: The default argument (optional, only for directives that take a single argument)
 - `options`: A dictionary of default options for the directive (optional)
 
 ## Supported browsers

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -29,7 +29,7 @@ D
 :::
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-basic.txt
@@ -78,7 +78,7 @@ B
 :::
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-card.txt
@@ -117,7 +117,7 @@ B
 :::
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-gutter.txt
@@ -154,7 +154,7 @@ C
 :::
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-card-columns.txt
@@ -246,7 +246,7 @@ Content
 
 ::::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-nested.txt

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -29,9 +29,7 @@ D
 :::
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-basic.txt
@@ -80,9 +78,7 @@ B
 :::
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-card.txt
@@ -121,9 +117,7 @@ B
 :::
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-gutter.txt
@@ -160,9 +154,7 @@ C
 :::
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-card-columns.txt
@@ -254,9 +246,7 @@ Content
 
 ::::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/grid-nested.txt

--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -17,9 +17,7 @@ Content 2
 
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/tab-basic.txt
@@ -70,9 +68,7 @@ Content 2
 
 ::::
 
-`````{dropdown} Syntax
-:icon: code
-:color: primary
+`````{dropdown-syntax} Syntax
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/tab-sync.txt

--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -17,7 +17,7 @@ Content 2
 
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/tab-basic.txt
@@ -68,7 +68,7 @@ Content 2
 
 ::::
 
-`````{dropdown-syntax} Syntax
+`````{dropdown-syntax}
 
 ````{tab-set-code}
 ```{literalinclude} ./snippets/myst/tab-sync.txt

--- a/sphinx_design/article_info.py
+++ b/sphinx_design/article_info.py
@@ -3,10 +3,9 @@ from typing import Optional
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
-from sphinx.util.docutils import SphinxDirective
 
 from .icons import get_octicon
-from .shared import SEMANTIC_COLORS, create_component, make_choice
+from .shared import SEMANTIC_COLORS, SdDirective, create_component, make_choice
 
 
 def setup_article_info(app: Sphinx):
@@ -14,7 +13,7 @@ def setup_article_info(app: Sphinx):
     app.add_directive("article-info", ArticleInfoDirective)
 
 
-class ArticleInfoDirective(SphinxDirective):
+class ArticleInfoDirective(SdDirective):
     """ """
 
     has_content = False
@@ -48,8 +47,7 @@ class ArticleInfoDirective(SphinxDirective):
             output = [para]
         return output
 
-    def run(self) -> list[nodes.Node]:  # noqa: PLR0915
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:  # noqa: PLR0915
         parse_fields = True  # parse field text
 
         top_grid = create_component(

--- a/sphinx_design/badges_buttons.py
+++ b/sphinx_design/badges_buttons.py
@@ -4,9 +4,9 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx import addnodes
 from sphinx.application import Sphinx
-from sphinx.util.docutils import ReferenceRole, SphinxDirective, SphinxRole
+from sphinx.util.docutils import ReferenceRole, SphinxRole
 
-from sphinx_design.shared import SEMANTIC_COLORS, make_choice, text_align
+from sphinx_design.shared import SEMANTIC_COLORS, SdDirective, make_choice, text_align
 
 ROLE_NAME_BADGE_PREFIX = "bdg"
 ROLE_NAME_LINK_PREFIX = "bdg-link"
@@ -127,7 +127,7 @@ class XRefBadgeRole(ReferenceRole):
         return [node], []
 
 
-class _ButtonDirective(SphinxDirective):
+class _ButtonDirective(SdDirective):
     """A base button directive."""
 
     required_arguments = 1
@@ -155,8 +155,7 @@ class _ButtonDirective(SphinxDirective):
         """Create the reference node."""
         raise NotImplementedError
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         rawtext = self.arguments[0]
         target = directives.uri(rawtext)
         classes = ["sd-sphinx-override", "sd-btn", "sd-text-wrap"]

--- a/sphinx_design/cards.py
+++ b/sphinx_design/cards.py
@@ -13,6 +13,7 @@ from ._compat import findall
 from .shared import (
     WARNING_TYPE,
     PassthroughTextElement,
+    SdDirective,
     create_component,
     is_component,
     make_choice,
@@ -45,7 +46,7 @@ class CardContent(NamedTuple):
     footer: Optional[tuple[int, StringList]] = None
 
 
-class CardDirective(SphinxDirective):
+class CardDirective(SdDirective):
     """A card component."""
 
     has_content = True
@@ -73,7 +74,7 @@ class CardDirective(SphinxDirective):
         "class-img-bottom": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
+    def run_with_defaults(self) -> list[nodes.Node]:
         return [self.create_card(self, self.arguments, self.options)]
 
     @classmethod
@@ -256,7 +257,7 @@ class CardDirective(SphinxDirective):
         #     ]
 
 
-class CardCarouselDirective(SphinxDirective):
+class CardCarouselDirective(SdDirective):
     """A component, which is a container for cards in a single scrollable row."""
 
     has_content = True
@@ -266,8 +267,7 @@ class CardCarouselDirective(SphinxDirective):
         "class": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         self.assert_has_content()
         try:
             cols = make_choice([str(i) for i in range(1, 13)])(

--- a/sphinx_design/dropdown.py
+++ b/sphinx_design/dropdown.py
@@ -4,10 +4,10 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.transforms.post_transforms import SphinxPostTransform
-from sphinx.util.docutils import SphinxDirective
 
 from sphinx_design.shared import (
     SEMANTIC_COLORS,
+    SdDirective,
     create_component,
     is_component,
     make_choice,
@@ -52,7 +52,7 @@ def depart_dropdown_title(self, node):
     self.body.append("</summary>")
 
 
-class DropdownDirective(SphinxDirective):
+class DropdownDirective(SdDirective):
     """A directive to generate a collapsible container.
 
     Note: This directive generates a single container,
@@ -87,8 +87,7 @@ class DropdownDirective(SphinxDirective):
         "class-body": directives.class_option,
     }
 
-    def run(self):
-        """Run the directive"""
+    def run_with_defaults(self) -> list[nodes.Node]:
         # default classes
         classes = {
             "container_classes": self.options.get("margin", ["sd-mb-3"])
@@ -149,7 +148,7 @@ class DropdownHtmlTransform(SphinxPostTransform):
     default_priority = 199
     formats = ("html",)
 
-    def run(self):
+    def run(self) -> None:
         """Run the transform"""
         document: nodes.document = self.document
         for node in findall(document)(lambda node: is_component(node, "dropdown")):

--- a/sphinx_design/grids.py
+++ b/sphinx_design/grids.py
@@ -3,12 +3,12 @@ from typing import Optional
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
-from sphinx.util.docutils import SphinxDirective
 from sphinx.util.logging import getLogger
 
 from .cards import CardDirective
 from .shared import (
     WARNING_TYPE,
+    SdDirective,
     create_component,
     is_component,
     make_choice,
@@ -94,7 +94,7 @@ def gutter_option(argument: Optional[str]) -> list[str]:
     return _media_option(argument, "sd-g-", min_num=0, max_num=5)
 
 
-class GridDirective(SphinxDirective):
+class GridDirective(SdDirective):
     """A grid component, which is a container for grid items (i.e. columns)."""
 
     has_content = True
@@ -111,8 +111,7 @@ class GridDirective(SphinxDirective):
         "class-row": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         try:
             column_classes = (
                 row_columns_option(self.arguments[0]) if self.arguments else []
@@ -157,7 +156,7 @@ class GridDirective(SphinxDirective):
         return [container]
 
 
-class GridItemDirective(SphinxDirective):
+class GridItemDirective(SdDirective):
     """An item within a grid row.
 
     Can "occupy" 1 to 12 columns.
@@ -174,8 +173,7 @@ class GridItemDirective(SphinxDirective):
         "class": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         if not is_component(self.state_machine.node, "grid-row"):
             LOGGER.warning(
                 f"The parent of a 'grid-item' should be a 'grid-row' [{WARNING_TYPE}.grid]",
@@ -205,7 +203,7 @@ class GridItemDirective(SphinxDirective):
         return [column]
 
 
-class GridItemCardDirective(SphinxDirective):
+class GridItemCardDirective(SdDirective):
     """An item within a grid row, with an internal card."""
 
     has_content = True
@@ -237,8 +235,7 @@ class GridItemCardDirective(SphinxDirective):
         "class-img-bottom": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         if not is_component(self.state_machine.node, "grid-row"):
             LOGGER.warning(
                 f"The parent of a 'grid-item' should be a 'grid-row' [{WARNING_TYPE}.grid]",

--- a/sphinx_design/icons.py
+++ b/sphinx_design/icons.py
@@ -8,11 +8,11 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util import logging
-from sphinx.util.docutils import SphinxDirective, SphinxRole
+from sphinx.util.docutils import SphinxRole
 
 from . import compiled
 from ._compat import read_text
-from .shared import WARNING_TYPE
+from .shared import WARNING_TYPE, SdDirective
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class OcticonRole(SphinxRole):
         return [node], []
 
 
-class AllOcticons(SphinxDirective):
+class AllOcticons(SdDirective):
     """Directive to generate all octicon icons.
 
     Primarily for self documentation.
@@ -152,8 +152,7 @@ class AllOcticons(SphinxDirective):
         "class": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         classes = self.options.get("class", [])
         table = nodes.table()
         group = nodes.tgroup(cols=2)

--- a/sphinx_design/shared.py
+++ b/sphinx_design/shared.py
@@ -1,10 +1,18 @@
 """Shared constants and functions."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Optional
+from typing import final
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util.logging import getLogger
+
+LOGGER = getLogger(__name__)
 
 WARNING_TYPE = "design"
 
@@ -21,6 +29,84 @@ SEMANTIC_COLORS = (
     "white",
     "black",
 )
+
+
+def setup_custom_directives(
+    app: Sphinx, config: Config, directive_map: dict[str, SdDirective]
+) -> None:
+    conf_value = config.sd_custom_directives
+
+    def _warn(msg):
+        LOGGER.warning(
+            f"sd_custom_directives: {msg}", type=WARNING_TYPE, subtype="config"
+        )
+
+    if not isinstance(conf_value, dict):
+        _warn("must be a dictionary")
+        config.sd_custom_directives = {}
+        return
+    for name, data in conf_value.items():
+        if not isinstance(name, str):
+            _warn(f"key must be a string: {name!r}")
+            continue
+        if not isinstance(data, dict):
+            _warn(f"{name!r} value must be a dictionary")
+            continue
+        if "inherit" not in data:
+            _warn(f"{name!r} value must have an 'inherit' key")
+            continue
+        if data["inherit"] not in directive_map:
+            _warn(f"'{name}.inherit' is an unknown directive key: {data['inherit']}")
+            continue
+        directive_cls = directive_map[data["inherit"]]
+        if "options" in data:
+            if not isinstance(data["options"], dict):
+                _warn(f"'{name}.options' value must be a dictionary")
+                continue
+            for key, value in data["options"].items():
+                if key not in directive_cls.option_spec:
+                    _warn(f"'{name}.options' unknown key {key!r}")
+                    continue
+                if not isinstance(value, str):
+                    _warn(f"'{name}.options.{key}' value must be a string")
+                    continue
+        app.add_directive(name, directive_cls, override=True)
+
+
+class SdDirective(SphinxDirective):
+    """Base class for all sphinx-design directives.
+
+    Having a base class allows for shared functionality to be implemented in one place.
+    Namely, we allow for default options to be configured, per directive name.
+
+    This class should be subclassed by all directives in the sphinx-design extension.
+    """
+
+    # TODO perhaps ideally there would be separate sphinx extension,
+    # that generalises the concept of default directive options (that does not require subclassing)
+    # but for now I couldn't think of a trivial way to achieve this.
+
+    @final
+    def run(self) -> list[nodes.Node]:
+        """Run the directive.
+
+        This method should not be overridden, instead override `run_with_defaults`.
+        """
+        if (data := self.config.sd_custom_directives.get(self.name)) and (
+            options := data.get("options")
+        ):
+            for key, value in options.items():
+                if key not in self.options and key in self.option_spec:
+                    # TODO check for exceptions and handle them
+                    self.options[key] = self.option_spec[key](str(value))
+        return self.run_with_defaults()
+
+    def run_with_defaults(self) -> list[nodes.Node]:
+        """Run the directive, after default options have been set.
+
+        This method should be overridden by subclasses.
+        """
+        raise NotImplementedError
 
 
 def create_component(
@@ -53,7 +139,7 @@ def make_choice(choices: Sequence[str]):
 
 
 def _margin_or_padding_option(
-    argument: Optional[str],
+    argument: str | None,
     class_prefix: str,
     allowed: Sequence[str],
 ) -> list[str]:
@@ -78,7 +164,7 @@ def _margin_or_padding_option(
     )
 
 
-def margin_option(argument: Optional[str]) -> list[str]:
+def margin_option(argument: str | None) -> list[str]:
     """Validate the margin is one (all) or four (top bottom left right) integers,
     between 0 and 5 or 'auto'.
     """
@@ -87,14 +173,14 @@ def margin_option(argument: Optional[str]) -> list[str]:
     )
 
 
-def padding_option(argument: Optional[str]) -> list[str]:
+def padding_option(argument: str | None) -> list[str]:
     """Validate the padding is one (all) or four (top bottom left right) integers,
     between 0 and 5.
     """
     return _margin_or_padding_option(argument, "sd-p", ("0", "1", "2", "3", "4", "5"))
 
 
-def text_align(argument: Optional[str]) -> list[str]:
+def text_align(argument: str | None) -> list[str]:
     """Validate the text align is left, right, center or justify."""
     value = directives.choice(argument, ["left", "right", "center", "justify"])
     return [f"sd-text-{value}"]

--- a/sphinx_design/tabs.py
+++ b/sphinx_design/tabs.py
@@ -2,11 +2,10 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.transforms.post_transforms import SphinxPostTransform
-from sphinx.util.docutils import SphinxDirective
 from sphinx.util.logging import getLogger
 
 from ._compat import findall
-from .shared import WARNING_TYPE, create_component, is_component
+from .shared import WARNING_TYPE, SdDirective, create_component, is_component
 
 LOGGER = getLogger(__name__)
 
@@ -20,7 +19,7 @@ def setup_tabs(app: Sphinx) -> None:
     app.add_node(sd_tab_label, html=(visit_tab_label, depart_tab_label))
 
 
-class TabSetDirective(SphinxDirective):
+class TabSetDirective(SdDirective):
     """A container for a set of tab items."""
 
     has_content = True
@@ -28,8 +27,7 @@ class TabSetDirective(SphinxDirective):
         "class": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         self.assert_has_content()
         tab_set = create_component(
             "tab-set", classes=["sd-tab-set", *self.options.get("class", [])]
@@ -49,7 +47,7 @@ class TabSetDirective(SphinxDirective):
         return [tab_set]
 
 
-class TabItemDirective(SphinxDirective):
+class TabItemDirective(SdDirective):
     """A single tab item in a tab set.
 
     Note: This directive generates a single container,
@@ -79,8 +77,7 @@ class TabItemDirective(SphinxDirective):
         "class-content": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         self.assert_has_content()
         if not is_component(self.state_machine.node, "tab-set"):
             LOGGER.warning(
@@ -119,7 +116,7 @@ class TabItemDirective(SphinxDirective):
         return [tab_item]
 
 
-class TabSetCodeDirective(SphinxDirective):
+class TabSetCodeDirective(SdDirective):
     """A container for a set of tab items, generated from code blocks."""
 
     has_content = True
@@ -129,8 +126,7 @@ class TabSetCodeDirective(SphinxDirective):
         "class-item": directives.class_option,
     }
 
-    def run(self) -> list[nodes.Node]:
-        """Run the directive."""
+    def run_with_defaults(self) -> list[nodes.Node]:
         self.assert_has_content()
         tab_set = create_component(
             "tab-set", classes=["sd-tab-set", *self.options.get("class-set", [])]

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -150,3 +150,35 @@ def test_sd_hide_title_myst(
         extension=".xml",
         encoding="utf8",
     )
+
+
+def test_sd_custom_directives(
+    sphinx_builder: Callable[..., SphinxBuilder], file_regression
+):
+    """Test that the defaults are used."""
+    builder = sphinx_builder(
+        conf_kwargs={
+            "extensions": ["myst_parser", "sphinx_design"],
+            "sd_custom_directives": {
+                "dropdown-syntax": {
+                    "inherit": "dropdown",
+                    "argument": "Syntax",
+                    "options": {
+                        "color": "primary",
+                        "icon": "code",
+                    },
+                }
+            },
+        }
+    )
+    content = "# Heading\n\n```{dropdown-syntax}\ncontent\n```"
+    builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
+    builder.build()
+    doctree = builder.get_doctree("index", post_transforms=False)
+    doctree.attributes.pop("translation_progress", None)  # added in sphinx 7.1
+    file_regression.check(
+        doctree.pformat(),
+        basename="sd_custom_directives",
+        extension=".xml",
+        encoding="utf8",
+    )

--- a/tests/test_snippets/sd_custom_directives.xml
+++ b/tests/test_snippets/sd_custom_directives.xml
@@ -1,0 +1,9 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="code" is_div="True" opened="False" title_classes="sd-bg-primary sd-bg-text-primary" type="dropdown">
+            <rubric>
+                Syntax
+            <paragraph>
+                content


### PR DESCRIPTION
You can use the `sd_custom_directives` configuration option in your `conf.py` to add custom directives, with default option values:

```python
sd_custom_directives = {
    "dropdown-syntax": {
        "inherit": "dropdown",
        "argument": "Syntax",
        "options": {
            "color": "primary",
            "icon": "code",
        },
    }
}
```

The key is the new directive name to add, and the value is a dictionary with the following keys:

- `inherit`: The directive to inherit from (e.g. `dropdown`)
- `argument`: The default argument (optional, only for directives that take a single argument)
- `options`: A dictionary of default options for the directive (optional)