### PR TITLE
refactor: Remove unused constants

### DIFF
--- a/sphinx_design/icons.py
+++ b/sphinx_design/icons.py
@@ -16,15 +16,6 @@ from .shared import WARNING_TYPE, SdDirective
 
 logger = logging.getLogger(__name__)
 
-OCTICON_VERSION = "v19.8.0"
-
-OCTICON_CSS = """\
-.octicon {
-  display: inline-block;
-  vertical-align: text-top;
-  fill: currentColor;
-}"""
-
 
 def setup_icons(app: Sphinx) -> None:
     app.add_role("octicon", OcticonRole())


### PR DESCRIPTION
Thank you for this awesome library.
I referred to the implementation of the octicon role in [icons.py (a3bdfa3)](https://github.com/executablebooks/sphinx-design/blob/a3bdfa3742c25a7261a8301dfbb2a09e9700d325/sphinx_design/icons.py).

In reading the implementation, I noticed some unused code, so I propose to remove it.

```sh
$ git grep OCTICON_CSS
sphinx_design/icons.py:OCTICON_CSS = """\
$ git grep OCTICON_VERSION
sphinx_design/icons.py:OCTICON_VERSION = "v19.8.0"
```