### PR TITLE
expand sphinx requirement from `>=5,<8` to `>=5,<9`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "extension", "material design", "web components"]
 requires-python = ">=3.9"
-dependencies = ["sphinx>=5,<8"]
+dependencies = ["sphinx>=5,<9"]
 
 [project.urls]
 Homepage = "https://github.com/executablebooks/sphinx-design"


### PR DESCRIPTION
resolves #206

quick tests run locally passed so there _should_ be full compatibility. 