### PR TITLE
Fix missing required RTD configuration key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,6 @@ python:
           - rtd
 
 sphinx:
+  configuration: docs/conf.py
   builder: html
   fail_on_warning: true


### PR DESCRIPTION
ReadTheDocs has made the `sphinx.configuration` key required, so all RTD builds of `sphinx-design` are currently failing.

* Example failing build: https://app.readthedocs.org/projects/sphinx-design/builds/28051218/
* Read more: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/