### PR TITLE
Fix build failure with newer sphinx dependencies:

### DIFF
--- a/tests/test_snippets/sd_custom_directives.xml
+++ b/tests/test_snippets/sd_custom_directives.xml
@@ -2,7 +2,7 @@
     <section ids="heading" names="heading">
         <title>
             Heading
-        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="code" is_div="True" opened="False" title_classes="sd-bg-primary sd-bg-text-primary" type="dropdown">
+        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="1" icon="code" is_div="1" opened="0" title_classes="sd-bg-primary sd-bg-text-primary" type="dropdown">
             <rubric>
                 Syntax
             <paragraph>

--- a/tests/test_snippets/snippet_pre_dropdown-basic.xml
+++ b/tests/test_snippets/snippet_pre_dropdown-basic.xml
@@ -2,15 +2,15 @@
     <section ids="heading" names="heading">
         <title>
             Heading
-        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="False" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="0" icon="True" is_div="1" opened="0" title_classes="" type="dropdown">
             <paragraph>
                 Dropdown content
-        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="1" icon="True" is_div="1" opened="0" title_classes="" type="dropdown">
             <rubric>
                 Dropdown title
             <paragraph>
                 Dropdown content
-        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="True" title_classes="" type="dropdown">
+        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="1" icon="True" is_div="1" opened="0" title_classes="" type="dropdown">
             <rubric>
                 Open dropdown
             <paragraph>

--- a/tests/test_snippets/snippet_pre_dropdown-options.xml
+++ b/tests/test_snippets/snippet_pre_dropdown-options.xml
@@ -2,7 +2,7 @@
     <section ids="heading" names="heading">
         <title>
             Heading
-        <container body_classes="class-body" chevron="True" container_classes="sd-m-1 class-container" design_component="dropdown" has_title="True" icon="alert" is_div="True" opened="False" title_classes="class-title sd-bg-info sd-bg-text-info" type="dropdown">
+        <container body_classes="class-body" chevron="True" container_classes="sd-m-1 class-container" design_component="dropdown" has_title="1" icon="alert" is_div="1" opened="0" title_classes="class-title sd-bg-info sd-bg-text-info" type="dropdown">
             <rubric ids="target" names="target">
                 Title
             <paragraph>


### PR DESCRIPTION
=================================== FAILURES =================================== __________________________ test_sd_custom_directives ___________________________

sphinx_builder = <function sphinx_builder.<locals>._create_project at 0x73427f5c0900> file_regression = <pytest_regressions.file_regression.FileRegressionFixture object at 0x73427f8ba2c0>

    @pytest.mark.skipif(not MYST_INSTALLED, reason="myst-parser not installed")
    def test_sd_custom_directives(
        sphinx_builder: Callable[..., SphinxBuilder], file_regression
    ):
        """Test that the defaults are used."""
        builder = sphinx_builder(
            conf_kwargs={
                "extensions": ["myst_parser", "sphinx_design"],
                "sd_custom_directives": {
                    "dropdown-syntax": {
                        "inherit": "dropdown",
                        "argument": "Syntax",
                        "options": {
                            "color": "primary",
                            "icon": "code",
                        },
                    }
                },
            }
        )
        content = "# Heading\n\n```{dropdown-syntax}\ncontent\n```"
        builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
        builder.build()
        doctree = builder.get_doctree("index", post_transforms=False)
        doctree.attributes.pop("translation_progress", None)  # added in sphinx 7.1
>       file_regression.check(
            doctree.pformat(),
            basename="sd_custom_directives",
            extension=".xml",
            encoding="utf8",
        )
E       AssertionError: FILES DIFFER:
E       /tmp/pytest-of-pbuilder/pytest-0/test_sd_custom_directives0/test_snippets/sd_custom_directives.xml
E       /tmp/pytest-of-pbuilder/pytest-0/test_sd_custom_directives0/test_snippets/sd_custom_directives.obtained.xml
E       HTML DIFF: /tmp/pytest-of-pbuilder/pytest-0/test_sd_custom_directives0/test_snippets/sd_custom_directives.obtained.diff.html
E       ---
E       +++
E       @@ -2,7 +2,7 @@
E            <section ids="heading" names="heading">
E                <title>
E                    Heading
E       -        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="code" is_div="True" opened="False" title_classes="sd-bg-primary sd-bg-text-primary" type="dropdown">
E       +        <container body_classes="" chevron="True" container_classes="sd-mb-3" design_component="dropdown" has_title="1" icon="code" is_div="1" opened="0" title_classes="sd-bg-primary sd-bg-text-primary" type="dropdown">
E                    <rubric>
E                        Syntax
E                    <paragraph>

tests/test_snippets.py:190: AssertionError
=============================== warnings summary =============================== tests/test_snippets.py::test_sd_hide_title_rst
tests/test_snippets.py::test_sd_hide_title_myst
tests/test_snippets.py::test_sd_custom_directives