### PR TITLE
TST: test against sphinx 9.0, remove upper bound on sphinx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
           python-version: "3.10"
           sphinx-version: "~=8.0"
           extras: "testing-no-myst"  # TODO myst does not yet support Sphinx 8.0
+        - os: ubuntu-latest
+          python-version: "3.10"
+          sphinx-version: "~=9.0"
+          extras: "testing-no-myst"  # TODO myst does not yet support Sphinx 9.0
         - os: windows-latest
           python-version: "3.9"
           sphinx-version: "~=7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "extension", "material design", "web components"]
 requires-python = ">=3.9"
-dependencies = ["sphinx>=6,<9"]
+dependencies = ["sphinx>=6"]
 
 [project.urls]
 Homepage = "https://github.com/executablebooks/sphinx-design"


### PR DESCRIPTION
Address #245
I propose dropping the upper bound altogether because it's preventing anyone downstream to even test sphinx 9.0