### PR TITLE
♻️ Remove unused constants

### DIFF
--- a/sphinx_design/icons.py
+++ b/sphinx_design/icons.py
@@ -16,15 +16,6 @@ from .shared import WARNING_TYPE, SdDirective
 
 logger = logging.getLogger(__name__)
 
-OCTICON_VERSION = "v19.8.0"
-
-OCTICON_CSS = """\
-.octicon {
-  display: inline-block;
-  vertical-align: text-top;
-  fill: currentColor;
-}"""
-
 
 def setup_icons(app: Sphinx) -> None:
     app.add_role("octicon", OcticonRole())


### PR DESCRIPTION
Carries #205 by @ftnext (commit authorship preserved): removes the unused `OCTICON_VERSION` and `OCTICON_CSS` constants from `icons.py`.

Re-created on a maintainer branch because the original fork branch could not be updated to re-trigger the required status checks (the 2024 CI runs are too old to re-run).