### PR TITLE
⬆️ Refresh dev/docs pins, group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,15 @@ updates:
       prefix: ⬆️
     schedule:
       interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
   - package-ecosystem: pip
     directory: /
     commit-message:
       prefix: ⬆️
     schedule:
       interval: monthly
+    groups:
+      python-deps:
+        patterns: ["*"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,9 @@ repos:
     rev: v2.1.0
     hooks:
     - id: mypy
-      additional_dependencies: []
+      # install sphinx so the hook type-checks with real types,
+      # matching the tox mypy environment (which installs the package)
+      additional_dependencies: [sphinx]
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Homepage = "https://github.com/executablebooks/sphinx-design"
 Documentation = "https://sphinx-design.readthedocs.io"
 
 [project.optional-dependencies]
-code-style = ["pre-commit>=3,<4"]
+code-style = ["pre-commit>=3,<5"]
 rtd = ["myst-parser>=4,<6"]
 testing = [
     "myst-parser>=4,<6",
@@ -50,15 +50,16 @@ testing-no-myst = [
     "defusedxml",
 ]
 
-theme-furo = ["furo~=2024.7.18"]
-theme-pydata = ["pydata-sphinx-theme~=0.15.2"]
-theme-rtd = ["sphinx-rtd-theme~=2.0"]
-theme-sbt = ["sphinx-book-theme~=1.1"]
-theme-im = ["sphinx-immaterial~=0.12.2"]
+theme-furo = ["furo~=2025.12"]
+theme-pydata = ["pydata-sphinx-theme~=0.20.0"]
+theme-rtd = ["sphinx-rtd-theme~=3.1"]
+theme-sbt = ["sphinx-book-theme~=1.2"]
+theme-im = ["sphinx-immaterial~=0.13.9"]
 
 [dependency-groups]
-mypy = ["mypy==1.19.1"]
-ruff = ["ruff==0.14.11"]
+# keep in sync with the mirrors-mypy / ruff-pre-commit revs in .pre-commit-config.yaml
+mypy = ["mypy==2.1.0"]
+ruff = ["ruff==0.15.20"]
 
 [tool.flit.sdist]
 exclude = [

--- a/sphinx_design/dropdown.py
+++ b/sphinx_design/dropdown.py
@@ -1,5 +1,7 @@
 """Originally Adapted from sphinxcontrib.details.directive"""
 
+from typing import Any
+
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
@@ -148,7 +150,7 @@ class DropdownHtmlTransform(SphinxPostTransform):
     default_priority = 199
     formats = ("html",)
 
-    def run(self) -> None:
+    def run(self, **kwargs: Any) -> None:
         """Run the transform"""
         document: nodes.document = self.document
         for node in findall(document)(lambda node: is_component(node, "dropdown")):

--- a/sphinx_design/extension.py
+++ b/sphinx_design/extension.py
@@ -71,15 +71,15 @@ def capture_directives(app: Sphinx):
         directive_map[name] = directive
         add_directive(name, directive, **kwargs)
 
-    app.add_directive = _add_directive
+    app.add_directive = _add_directive  # type: ignore[assignment,method-assign]
     yield directive_map
-    app.add_directive = add_directive
+    app.add_directive = add_directive  # type: ignore[method-assign]
 
 
 def update_css_js(app: Sphinx):
     """Copy the CSS to the build directory."""
     # reset changed identifier
-    app.env.sphinx_design_css_changed = False
+    app.env.sphinx_design_css_changed = False  # type: ignore[attr-defined]
     # setup up new static path in output dir
     static_path = (Path(app.outdir) / "_sphinx_design_static").absolute()
     static_existed = static_path.exists()
@@ -105,7 +105,7 @@ def update_css_js(app: Sphinx):
     if css_path.exists():
         return
     if static_existed:
-        app.env.sphinx_design_css_changed = True
+        app.env.sphinx_design_css_changed = True  # type: ignore[attr-defined]
     for path in static_path.glob("*.css"):
         path.unlink()
     css_path.write_text(content, encoding="utf8")
@@ -113,7 +113,7 @@ def update_css_js(app: Sphinx):
 
 def update_css_links(app: Sphinx, env: BuildEnvironment):
     """If CSS has changed, all files must be re-written, to include the correct stylesheets."""
-    if env.sphinx_design_css_changed:
+    if env.sphinx_design_css_changed:  # type: ignore[attr-defined]
         return list(env.all_docs.keys())
 
 

--- a/sphinx_design/tabs.py
+++ b/sphinx_design/tabs.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
@@ -215,7 +217,7 @@ class TabSetHtmlTransform(SphinxPostTransform):
     default_priority = 200
     formats = ("html",)
 
-    def run(self) -> None:
+    def run(self, **kwargs: Any) -> None:
         """Run the transform."""
 
         # setup id generators


### PR DESCRIPTION
Completes the pin-refresh item of #265 Phase 0 (supersedes the closed dependabot PRs #221/#225/#226/#227):

- **theme extras**: `furo~=2025.12`, `pydata-sphinx-theme~=0.20.0`, `sphinx-rtd-theme~=3.1`, `sphinx-book-theme~=1.2`, `sphinx-immaterial~=0.13.9`
- **code-style**: allow pre-commit v4 (`>=3,<5`)
- **dependency-groups**: sync `mypy==2.1.0` / `ruff==0.15.20` with the pre-commit revs bumped in #262, so tox and pre-commit agree
- **mypy 2.1 fixes** (surfaced by the sync — the pre-commit hook in #262 only checked changed files, so these were latent): add `**kwargs` to the two `SphinxPostTransform.run` overrides to match the supertype signature; targeted `type: ignore`s for the `add_directive` capture monkeypatch and the dynamic env attribute (all three of the latter are removed entirely by the planned static-asset rework)
- **dependabot**: `groups` config so actions/pip bumps arrive as one PR per ecosystem

Validation at the new pins: `tox -e py311` (110 passed), `ruff check`/`ruff format --check`, `mypy` clean, and docs builds green for alabaster/furo/rtd/pydata/sbt. The `docs-im` build could not be verified in this environment — sphinx-immaterial fetches fonts.google.com metadata at build time and the network here blocks it (confirmed the previous pin `0.12.2` fails identically here, so this is environmental, not a regression) — worth one spot-check on an unrestricted network.
