### PR TITLE
📚 Clarify that buttons are styled links

### DIFF
--- a/docs/badges_buttons.md
+++ b/docs/badges_buttons.md
@@ -102,7 +102,29 @@ See [Bootstrap badges](https://getbootstrap.com/docs/5.0/components/badge/) for 
 
 ## Buttons
 
-Buttons allow users to navigate to external (`button-link`) / internal (`button-ref`) links with a single tap.
+Buttons in Sphinx Design are actually links:
+
+- Links that can be styled to look like
+  [Bootstrap buttons](https://getbootstrap.com/docs/5.0/components/buttons/)
+- Links that are either external (`button-link`) or internal (`button-ref`)
+
+Most of the time, you should create links using the link syntax for the language
+you've chosen:
+
+- [Markdown/MyST links and cross-references](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#examples)
+- [rST links and cross-references](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#hyperlinks)
+
+Sometimes, though, you may want to call attention to a particular link or set of
+links, or set them apart visually from other links on the site.
+
+:::{admonition} Note on accessibility
+
+Despite the name, `button-link` and `button-ref` do **not** convert to
+`<button>` tags in HTML. They are output as `<a>` tags and use CSS to achieve
+the button look. This has important accessibility implications. For example,
+assistive tech will include Sphinx Design "buttons" when asked to present a list
+of all the links on the page.
+:::
 
 ```{button-link} https://example.com
 ```
@@ -175,8 +197,6 @@ Use the `click-parent` option to make the button's parent container also clickab
 ```
 
 :::
-
-See the [Material Design](https://material.io/components/buttons) and [Bootstrap](https://getbootstrap.com/docs/5.0/components/buttons/) descriptions for further details.
 
 ### `button-link` and `button-ref` options
 


### PR DESCRIPTION
Carries the documentation clarification from #158 (thanks @gabalafou — the commit is authored to you) forward onto the current docs:

- The Buttons intro now explains that `button-link`/`button-ref` are *links styled as buttons*, and that plain link syntax is usually the right tool — these directives are for calling visual attention to a link.
- Adds the accessibility admonition: the output is an `<a>` tag, not `<button>`, so assistive tech treats them as links (e.g. they appear in links lists).
- Drops the stale Material Design/Bootstrap "further details" sentence.

The original PR's snippet/fixture additions are not carried: they predate three rewrites of this docs page and the button test-suite additions (#281's `tests/test_buttons.py` now covers `button-ref` rendering directly), so only the prose — the durable part — comes forward, lightly adapted.

Supersedes #158 (will be closed with credit once this merges).