### PR TITLE
🔧 Compile the docs PDF in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,38 @@ jobs:
     - name: Build documentation
       run: sphinx-build -nW --keep-going -b ${{ matrix.format }} docs/ docs/_build/${{ matrix.format }}
 
+  docs-build-pdf:
+
+    # compiling the LaTeX sources catches what the sphinx build alone cannot:
+    # missing LaTeX packages and icon names unknown to fontawesome5.sty
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: pip
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[rtd]
+    - name: Install SVG conversion tools (for sphinx.ext.imgconverter)
+      run: sudo apt-get update -q && sudo apt-get install -y -q --no-install-recommends imagemagick librsvg2-bin
+    - name: Build LaTeX sources
+      run: sphinx-build -nW --keep-going -b latex docs/ docs/_build/latex
+    - name: Compile PDF
+      uses: xu-cheng/latex-action@v2
+      with:
+        working_directory: docs/_build/latex
+        root_file: sphinxdesign.tex
+    - name: Upload PDF
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-pdf
+        path: docs/_build/latex/sphinxdesign.pdf
+
   # https://github.com/marketplace/actions/alls-green#why
   check:  # This job does nothing and is only used for the branch protection
 
@@ -106,6 +138,7 @@ jobs:
     - pre-commit
     - tests
     - docs-build-format
+    - docs-build-pdf
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
     - name: Compile PDF
       uses: xu-cheng/latex-action@v4
       with:
+        # TeX Live 2026's colortbl loops with Sphinx <9.1.1 table colorrows
+        # (sphinx-doc/sphinx#14465) — drop this pin once on sphinx >=9.1.1
+        texlive_version: "2025"
         working_directory: docs/_build/latex
         root_file: sphinxdesign.tex
     - name: Upload PDF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[rtd]
+    - name: Install SVG conversion tools (for sphinx.ext.imgconverter)
+      if: matrix.format == 'latex'
+      run: sudo apt-get update -q && sudo apt-get install -y -q --no-install-recommends imagemagick librsvg2-bin
     - name: Build documentation
       run: sphinx-build -nW --keep-going -b ${{ matrix.format }} docs/ docs/_build/${{ matrix.format }}
 
@@ -119,7 +122,7 @@ jobs:
     - name: Build LaTeX sources
       run: sphinx-build -nW --keep-going -b latex docs/ docs/_build/latex
     - name: Compile PDF
-      uses: xu-cheng/latex-action@v2
+      uses: xu-cheng/latex-action@v4
       with:
         working_directory: docs/_build/latex
         root_file: sphinxdesign.tex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- 🔧 MAINTAIN: CI now compiles the documentation's LaTeX output to PDF
+  (exercising the `sd_fontawesome_latex="fontawesome5"` icon path, which the
+  docs now use), and the fa-build hint recommends `"fontawesome5"` over the
+  legacy FontAwesome 4 package ({pr}`PRNUM`)
 - ✨ NEW: `sd_fontawesome_version` makes icon role names version-agnostic:
   any spelling (`fas`, `fa-solid`, ...) can emit the FontAwesome `"4"`, `"5"`
   or `"6"` class scheme, so upgrading FontAwesome is a one-line `conf.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - 🔧 MAINTAIN: CI now compiles the documentation's LaTeX output to PDF
   (exercising the `sd_fontawesome_latex="fontawesome5"` icon path, which the
   docs now use), and the fa-build hint recommends `"fontawesome5"` over the
-  legacy FontAwesome 4 package ({pr}`PRNUM`)
+  legacy FontAwesome 4 package ({pr}`289`)
 - ✨ NEW: `sd_fontawesome_version` makes icon role names version-agnostic:
   any spelling (`fas`, `fa-solid`, ...) can emit the FontAwesome `"4"`, `"5"`
   or `"6"` class scheme, so upgrading FontAwesome is a one-line `conf.py`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,13 @@ sd_fontawesome_latex = "fontawesome5"
 # missing glyphs. makeindex replaces xindy, which CI TeX images lack.
 latex_engine = "xelatex"
 latex_use_xindy = False
+latex_elements = {
+    # Sphinx >=9 auto-selects the newest FontAwesome LaTeX package installed
+    # for its admonition icons (fontawesome7 on full TeX Live 2025+), which
+    # hard-clashes with the fontawesome5 package sd_fontawesome_latex loads.
+    # Pin Sphinx's icons to the same package so there is a single FA load.
+    "sphinxsetup": "iconpackage=fontawesome5",
+}
 sd_custom_directives = {
     "dropdown-syntax": {
         "inherit": "dropdown",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,10 +9,21 @@ project = "Sphinx Design"
 copyright = "2021, Executable Book Project"
 author = "Executable Book Project"
 
-extensions = ["myst_parser", "sphinx_design", "sphinx.ext.extlinks"]
+extensions = [
+    "myst_parser",
+    "sphinx_design",
+    "sphinx.ext.extlinks",
+    # SVG images must be converted for the LaTeX/PDF build
+    "sphinx.ext.imgconverter",
+]
 
+# suppresses the warning for builders with no fontawesome support (e.g. man)
 suppress_warnings = ["design.fa-build"]
-sd_fontawesome_latex = True
+sd_fontawesome_latex = "fontawesome5"
+# pdflatex errors on emoji (e.g. in the changelog); xelatex only warns for
+# missing glyphs. makeindex replaces xindy, which CI TeX images lack.
+latex_engine = "xelatex"
+latex_use_xindy = False
 sd_custom_directives = {
     "dropdown-syntax": {
         "inherit": "dropdown",

--- a/sphinx_design/icons.py
+++ b/sphinx_design/icons.py
@@ -325,7 +325,8 @@ def visit_fontawesome_latex(self, node):
     else:
         logger.warning(
             "Fontawesome icons not included in LaTeX output, "
-            f"consider 'sd_fontawesome_latex=True' [{WARNING_TYPE}.fa-build]",
+            "consider 'sd_fontawesome_latex=\"fontawesome5\"' "
+            f"[{WARNING_TYPE}.fa-build]",
             location=node,
             type=WARNING_TYPE,
             subtype="fa-build",


### PR DESCRIPTION
CI has always *built* the LaTeX docs but never compiled them, so the PDF path (LaTeX packages, icon names, image formats) was unverified. This adds a `docs-build-pdf` job that compiles the LaTeX build into a real PDF with [xu-cheng/latex-action](https://github.com/xu-cheng/latex-action), wired into the `check` umbrella job, with the PDF uploaded as a build artifact.

Actually compiling surfaced four latent breaks, fixed here:

- the docs dogfooded `sd_fontawesome_latex = True` (the legacy FA4 `fontawesome` package) while using icon names (`skull`, `gitkraken`) that only exist from FA5 — the PDF could never have compiled; the docs now exercise the modern `sd_fontawesome_latex = "fontawesome5"` path instead (no behaviour change for users — `True` keeps working as before)
- the landing page's SVG logo cannot be embedded by LaTeX — `sphinx.ext.imgconverter` (backed by ImageMagick + librsvg, installed in the docs CI jobs) now converts it
- pdflatex hard-errors on the emoji in the changelog; `latex_engine = "xelatex"` demotes unknown glyphs to warnings (they render as blanks on the changelog pages; everything else is unaffected), and `latex_use_xindy = False` keeps makeindex so no xindy toolchain is needed (sphinx's generated `latexmkrc` maps the compile to xelatex, so the action's default arguments work unchanged)
- Sphinx ≥9 auto-selects the **newest** FontAwesome LaTeX package installed for its admonition icons — `fontawesome7` on full TeX Live 2025+, whose version guard hard-errors next to the `fontawesome5` that `sd_fontawesome_latex` loads (this is what failed the first CI run of this PR; invisible on leaner TeX installs, where the auto-detect falls through to fontawesome5). Fixed by pinning `sphinxsetup: iconpackage=fontawesome5` so Sphinx and sphinx-design agree on a single FA package. A library-level coordination (so users don't need this pin) is a candidate for the planned LaTeX pass.

Also: the `design.fa-build` warning hint now recommends `"fontawesome5"` rather than the legacy `True`.

## Verification

- Compiled locally with the action's exact latexmk invocation: 81-page PDF, exit 0; `pdffonts` shows FontAwesome5 Solid/Regular/Brands font subsets embedded (i.e. the icons genuinely rendered); the only missing-glyph warnings are the changelog emoji
- The fontawesome7 clash was reproduced locally against the real package's version guard (compile aborts exactly as in CI), and the pin verified: with `fontawesome7.sty` present, the pinned build compiles clean and never loads it
- `sphinx-build -nW --keep-going` green for latex, man and html with these conf changes (the man build is why `suppress_warnings = ["design.fa-build"]` stays — that builder warns per icon)
- ReadTheDocs is unaffected: it builds html only, where imgconverter is a no-op (SVG natively supported)
- Full test/lint/type matrix green; no test asserts the old warning wording (they match on the unchanged first clause)

## Notes

- This makes the PDF compile effectively required (via `check`). A docs example using an icon name unknown to `fontawesome5.sty` will now fail CI — that is the intended catch, but note it means a docs-only icon typo blocks merges.
- The action's TeX image is a floating latest; if TeXLive drift ever breaks the job, the `texlive_version` input can pin it.
- `docs-build-format (latex)` still runs the sphinx-side build redundantly with this job's build step; kept so the existing required-check contexts stay intact — it could be dropped from the matrix later if branch protection is adjusted accordingly.