### PR TITLE
Getting Started/Configuration/Global options: Excape '|' in table row for sd_fontawesome_latex

### DIFF
--- a/sphinx_design/config.py
+++ b/sphinx_design/config.py
@@ -249,7 +249,7 @@ class SdConfig:
             "types": (bool, str),
             "help": "Render fontawesome icons in LaTeX output: "
             'False/"none", True/"fontawesome", or "fontawesome5"',
-            "doc_type": "bool | str",
+            "doc_type": "bool \| str",
         },
     )
     tabs_storage_prefix: str = dc.field(


### PR DESCRIPTION
The table for the "Global options" contains a small error in the row for `sd_fontawesome_latex` (please see https://sphinx-design.readthedocs.io/en/rtd-theme/get_started.html#global-options):

<img width="500" alt="image" src="https://github.com/user-attachments/assets/91aa3a48-cdc5-4fcb-ad86-29e03e435b5d" />

This is because the `|` in the `doc_type` is not escaped and thus considered for the table in markdown: 
https://github.com/executablebooks/sphinx-design/blob/4f66f32e160f16d73dee5eed52cd91984935763f/sphinx_design/config.py#L245-L252

`doc_type` is used for setting up the table via:
https://github.com/executablebooks/sphinx-design/blob/4f66f32e160f16d73dee5eed52cd91984935763f/docs/conf.py#L142-L161

--- 

Without escaping the `|`
```
| aaa | bbb |
| --- | --- |
| xxx | `yyy | zzz` | 
```
the resulting table looks like:
| aaa | bbb |
| --- | --- |
| xxx | `yyy | zzz` | 

With escaping the `|` as `\|`
```
| aaa | bbb |
| --- | --- |
| xxx | `yyy \| zzz` | 
```
the resulting table looks like:
| aaa | bbb |
| --- | --- |
| xxx | `yyy \| zzz` | 